### PR TITLE
Update 3:4 Card tofeature have 316px Height (Instead of 336px)

### DIFF
--- a/consonant.html
+++ b/consonant.html
@@ -51,16 +51,16 @@
     <script type="text/javascript">
         var config = {
             collection: {
-                mode: "darkest", // Can be empty, "light", "dark", "darkest";
+                mode: "lightest", // Can be empty, "light", "dark", "darkest";
                 layout: {
-                    type: '3up', // Can be "2up", "3up", "4up", "5up";
+                    type: '5up', // Can be "2up", "3up", "4up", "5up";
                     gutter: '4x', // Can be "2x", "3x", "4x";
                     container: '1200MaxWidth', // Can be "83Percent", "1200MaxWidth", "32Margin";
                 },
                 resultsPerPage: '20',
                 endpoint: "./tests/card-collection/json-response-tests/smoke-tests/smoke.json",
                 totalCardsToShow: '100',
-                cardStyle: "1:2", // available options: "1:2", "3:4", "full-card", "half-height", "custom-card", "double-wide";
+                cardStyle: "3:4", // available options: "1:2", "3:4", "full-card", "half-height", "custom-card", "double-wide";
                 showTotalResults: 'true',
                 i18n: {
                     prettyDateIntervalFormat: '{LLL} {dd} | {timeRange} {timeZone}',

--- a/less/components/consonant/cards-grid.less
+++ b/less/components/consonant/cards-grid.less
@@ -92,6 +92,23 @@
                 min-height: @consonant-CardsGrid-smallerCardImgThreeFourthHeight;
             }
 
+            .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-text {
+                display: none;
+            }
+
+            .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-title {
+                margin-bottom: 0;
+                max-height: 1.375rem * 2;
+
+                .line-clamp(2);
+
+                &:first-child {
+                    max-height: 1.375rem * 3;
+
+                    .line-clamp(3);
+                }
+            }
+
             .consonant-OneHalfCard {
                 height: auto;
             }
@@ -124,6 +141,23 @@
 
             .consonant-ThreeFourthCard .consonant-ThreeFourthCard-img {
                 min-height: @consonant-CardsGrid-smallestCardImgThreeFourthHeight;
+            }
+
+            .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-text {
+                display: none;
+            }
+
+            .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-title {
+                margin-bottom: 0;
+                max-height: 1.375rem * 2;
+
+                .line-clamp(2);
+
+                &:first-child {
+                    max-height: 1.375rem * 3;
+
+                    .line-clamp(3);
+                }
             }
 
             .consonant-OneHalfCard {

--- a/less/components/consonant/cards/three-fourth.less
+++ b/less/components/consonant/cards/three-fourth.less
@@ -102,6 +102,7 @@
         &-label {
             display: block;
             max-width: 100%;
+            max-height: 1rem;
             margin-bottom: 4px;
 
             .font(@color: @consonantGray800);
@@ -116,6 +117,7 @@
         }
 
         &-title {
+            max-height: 1.375rem * 2;
             margin: 0 0 7px;
 
             .font(1.125rem, 1.375rem, 700, @consonantGray900);
@@ -126,7 +128,9 @@
             .line-clamp(2);
 
             &:only-child {
-                .line-clamp(3);
+                max-height: 1.375rem * 4;
+
+                .line-clamp(4);
             }
 
             &:empty {
@@ -134,10 +138,10 @@
             }
         }
 
-        &-label + &-title:not(:last-child) {
-            max-height: 1.375rem;
+        &-label + &-title:last-child {
+            max-height: 1.375rem * 3;
 
-            .line-clamp(1);
+            .line-clamp(3);
         }
 
         &-text {
@@ -159,10 +163,10 @@
             }
         }
 
-        &-label + &-text {
-            max-height: 1rem * 5;
+        &-label + &-text:last-child {
+            max-height: 1rem * 4;
 
-            .line-clamp(5);
+            .line-clamp(4);
         }
 
         &-label + &-title + &-text {

--- a/less/components/consonant/variables.less
+++ b/less/components/consonant/variables.less
@@ -78,7 +78,7 @@
 @consonant-FullCard-innerMinHeight: 108px;
 
 /* consonant-ThreeFourthCard */
-@consonant-ThreeFourthCard-imgHeight: 336px;
+@consonant-ThreeFourthCard-imgHeight: 316px;
 
 /* consonant-LeftFilters */
 @consonant-LeftFilters-mobBack-size: 32px;


### PR DESCRIPTION
Need this as it’s own PR to master. Not able to cherry-pick changes.
https://www.dropbox.com/s/bsvar31tjokk3kd/update-height-for-3-4-card.xd?dl=0

Idea is this’ll allow us to have an additional line of text for the 3:4 card.
